### PR TITLE
Minimize features in dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check-latest"
-version = "1.1.0"
+version = "1.0.2"
 authors = ["Spenser Black <spenserblack01@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "check-latest"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Spenser Black <spenserblack01@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Check if your rust executable is the latest available version"
 readme = "README.md"
@@ -21,10 +21,10 @@ async = []
 
 [dependencies]
 anyhow = "1"
-chrono = { version = "0.4", features = ["serde"] }
-reqwest = { version = "0.11", features = ["json"] }
-semver = { version = "1", features = ["serde"] }
-serde = { version = "1", features = ["derive"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
+semver = { version = "1", default-features = false, features = ["serde"] }
+serde = { version = "1", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 lazy_static = "1"


### PR DESCRIPTION
Since crate features are additive, pulling in `check-latest` as a dependency means your build will now include the default features for all the dependencies `check-latest` uses.  This can be particularly problematic for dependencies like reqwest, where it'll pull in `openssl` by default.

This change switches to use the minimally required set of features for dependencies, allowing callers of this crate to add more if they want. Notably, it also switches to use rustls by default - application developers can choose if they want to switch to full openssl.

The [rust guide](https://doc.rust-lang.org/cargo/reference/semver.html#cargo-remove-opt-dep) says this is probably a minor change, but I think it likely deserves a minor version bump since `reqwest` can behave very differently depending on which features are enabled.